### PR TITLE
Feature/restore reply to and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,23 @@
 
 Navigate to `/contact/crud/contact-template` to create a new form template.
 
-* Name: a unique name, e.g. 'reservation'
-* From Email: valid email
-* To Email: valid email
-* Captcha: this tells the contact module that a captcha will be used and that it has to validated against it (sets model scenario to captcha)
-* Form Schema: json-schema used to build a form with `dmstr/jsoneditor/JsonEditorWidget` (For more information about schema see examples on: https://github.com/json-editor/json-editor 
-)
+| property | required | description                                                                                                                                                                 |
+| ---------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Name | yes | a unique name, e.g. 'reservation'                                                                                                                                           |
+| From Email | yes | valid email used as 'From:' header                                                                                                                                          |
+| To Email | yes | one or more valid email addresses (comma separated) used as 'To:' header                                                                                                    |
+| Reply To Email | no | optional, valid email. Use this if you want to set 'Reply-To:' header to a fixed address for ALL mails. If set 'Reply to Schema Property' will be irgnored!                 |
+| Reply to Schema Property | no | can be used to define which property from schema should be used (if valid mail!) as 'Reply-To:' header. If 'Reply To Email' is set to a fixed address, this will be ignored |
+| Return Path | no | if set and is a valid email, this will be used as 'Return-Path:' header where bounce Mails will be send to. Handle with care                                                |
+| Captcha | no | this tells the contact module that a captcha will be used and that it has to validated against it (sets model scenario to captcha). Captcha widget is required in twig!     |
+| Form Schema | yes | json-schema used to build a form with `dmstr/jsoneditor/JsonEditorWidget` (For more information about schema see examples on: https://github.com/json-editor/json-editor)   |
 
-## conventions:
+## Upgrade hints:
 
-* if you have a property reply_to in your schema and send valid email address as value, this will be used as Reply-To: header in message
+- If the form was build with version <= 1.0.0 there was the convention, that property reply_to in your schema was used as 'Reply-To:' header in message.
+- this "magick" is removed! You must now set 'Reply to Schema Property' to 'reply_to' to get the same behavior!
+
+
 
 ## Twig templates (Views)
 
@@ -136,16 +143,6 @@ It uses a particular format for colors but the last 6 characters follow the css 
   "type": "object",
   "format": "grid",
   "properties": {
-    "reply_to": {
-      "type": "string",
-      "template": "{{email}}",
-      "options": {
-        "hidden": true
-      },
-      "watch": {
-        "email": "Email"
-      }
-    },
     "Company": {
       "type": "string",
       "minLength": 3,
@@ -269,17 +266,3 @@ It uses a particular format for colors but the last 6 characters follow the css 
 
 To enable the export feature add *kartik\grid\Module* to your project modules
 
-## Giiant CRUDs
-
-```bash
-yii giiant-batch \
-        --tables=app_dmstr_contact_template,app_dmstr_contact_log \
-        --tablePrefix=app_dmstr_ \
-        --modelNamespace=dmstr\\modules\\contact\\models \
-        --modelQueryNamespace=dmstr\\modules\\contact\\models\\query \
-        --crudViewPath=@dmstr/modules/contact/views/crud \
-        --crudControllerNamespace=dmstr\\modules\\contact\\controllers\\crud \
-        --crudSearchModelNamespace=dmstr\\modules\\contact\\models\\search \
-        --useTimestampBehavior=0 \
-        --interactive=0 
-```

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -99,12 +99,11 @@ class DefaultController extends Controller
     public function actionDone($schema)
     {
         $model = ContactLog::findOne(Yii::$app->session->get(self::CONTACT_FORM_ID_KEY));
+        Yii::$app->session->remove(self::CONTACT_FORM_ID_KEY);
 
         if ($model === null) {
-            throw new ForbiddenHttpException(Yii::t('contact', 'You are not allowed to access this page directly.'));
+            return $this->render('done-expired');
         }
-
-        Yii::$app->session->remove(self::CONTACT_FORM_ID_KEY);
 
         return $this->render(
             'done',

--- a/src/migrations/m201012_141325_alter_app_dmstr_contact_template_table.php
+++ b/src/migrations/m201012_141325_alter_app_dmstr_contact_template_table.php
@@ -6,11 +6,11 @@ class m201012_141325_alter_app_dmstr_contact_template_table extends Migration
 {
     public function safeUp()
     {
-        $this->addColumn('app_dmstr_contact_template','captcha', $this->boolean()->notNull()->defaultValue(null)->after('email_subject'));
+        $this->addColumn('{{%dmstr_contact_template}}','captcha', $this->boolean()->notNull()->defaultValue(null)->after('email_subject'));
     }
 
     public function safeDown()
     {
-        $this->dropColumn('app_dmstr_contact_template','captcha');
+        $this->dropColumn('{{%dmstr_contact_template}}','captcha');
     }
 }

--- a/src/migrations/m230214_071325_add_return_path_2_app_dmstr_contact_template_table.php
+++ b/src/migrations/m230214_071325_add_return_path_2_app_dmstr_contact_template_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use yii\db\Migration;
+
+class m230214_071325_add_return_path_2_app_dmstr_contact_template_table extends Migration
+{
+    public function safeUp()
+    {
+
+        $this->addColumn('app_dmstr_contact_template','return_path', $this->string()->null()->defaultValue(null)->after('to_email'));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('app_dmstr_contact_template','return_path');
+    }
+}

--- a/src/migrations/m230214_071325_add_return_path_2_app_dmstr_contact_template_table.php
+++ b/src/migrations/m230214_071325_add_return_path_2_app_dmstr_contact_template_table.php
@@ -7,11 +7,11 @@ class m230214_071325_add_return_path_2_app_dmstr_contact_template_table extends 
     public function safeUp()
     {
 
-        $this->addColumn('app_dmstr_contact_template','return_path', $this->string()->null()->defaultValue(null)->after('to_email'));
+        $this->addColumn('{{%dmstr_contact_template}}','return_path', $this->string()->null()->defaultValue(null)->after('to_email'));
     }
 
     public function safeDown()
     {
-        $this->dropColumn('app_dmstr_contact_template','return_path');
+        $this->dropColumn('{{%dmstr_contact_template}}','return_path');
     }
 }

--- a/src/migrations/m230214_081325_add_reply_to_schema_property_2_app_dmstr_contact_template_table.php
+++ b/src/migrations/m230214_081325_add_reply_to_schema_property_2_app_dmstr_contact_template_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use yii\db\Migration;
+
+class m230214_081325_add_reply_to_schema_property_2_app_dmstr_contact_template_table extends Migration
+{
+    public function safeUp()
+    {
+
+        $this->addColumn('app_dmstr_contact_template','reply_to_schema_property', $this->string()->null()->defaultValue(null)->after('return_path'));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('app_dmstr_contact_template','reply_to_schema_property');
+    }
+}

--- a/src/migrations/m230214_081325_add_reply_to_schema_property_2_app_dmstr_contact_template_table.php
+++ b/src/migrations/m230214_081325_add_reply_to_schema_property_2_app_dmstr_contact_template_table.php
@@ -7,11 +7,11 @@ class m230214_081325_add_reply_to_schema_property_2_app_dmstr_contact_template_t
     public function safeUp()
     {
 
-        $this->addColumn('app_dmstr_contact_template','reply_to_schema_property', $this->string()->null()->defaultValue(null)->after('return_path'));
+        $this->addColumn('{{%dmstr_contact_template}}','reply_to_schema_property', $this->string()->null()->defaultValue(null)->after('return_path'));
     }
 
     public function safeDown()
     {
-        $this->dropColumn('app_dmstr_contact_template','reply_to_schema_property');
+        $this->dropColumn('{{%dmstr_contact_template}}','reply_to_schema_property');
     }
 }

--- a/src/models/ContactLog.php
+++ b/src/models/ContactLog.php
@@ -8,6 +8,7 @@ use yii\behaviors\TimestampBehavior;
 use yii\db\ActiveQuery;
 use yii\db\Expression;
 use yii\helpers\Json;
+use yii\validators\EmailValidator;
 
 /**
  * This is the model class for table "app_dmstr_contact_log".
@@ -51,13 +52,23 @@ class ContactLog extends BaseContactLog
     public function sendMessage()
     {
 
+        $validator = new EmailValidator();
 
         $contactTemplate = $this->contactTemplate;
 
+        $data = Json::decode($this->json);
+
         $message = Yii::$app->mailer->compose();
         $message->setFrom($contactTemplate->from_email);
+        // if reply_to_email is set in template we always use this
         if (!empty($contactTemplate->reply_to_email)) {
             $message->setReplyTo($contactTemplate->reply_to_email);
+        } else {
+            # set optional Reply-To Header if reply_to is set in schema and is valid email address
+            if ((! empty($data['reply_to'])) && ($validator->validate($data['reply_to']))){
+                $message->setReplyTo($data['reply_to']);
+            }
+        }
         }
 
         $to = array_filter(array_map('trim', explode(',', $contactTemplate->to_email)));

--- a/src/models/ContactTemplate.php
+++ b/src/models/ContactTemplate.php
@@ -14,6 +14,9 @@ use yii\validators\EmailValidator;
 class ContactTemplate extends BaseContactTemplate
 {
 
+    const TMPL_PREFIX = 'contact:';
+    const TMPL_SEND_SUFFIX = ':send';
+
     /**
      * @inheritdoc
      */

--- a/src/models/ContactTemplate.php
+++ b/src/models/ContactTemplate.php
@@ -35,7 +35,7 @@ class ContactTemplate extends BaseContactTemplate
     public function rules()
     {
         $rules = parent::rules();
-        $rules['single_mail_value'] = [['from_email', 'reply_to_email'], 'email', 'skipOnEmpty' => true];
+        $rules['single_mail_value'] = [['from_email', 'reply_to_email', 'return_path'], 'email', 'skipOnEmpty' => true];
         $rules['multi_mail_value'] = [['to_email'], 'validateMultiMailValues', 'skipOnEmpty' => true];
         return $rules;
     }
@@ -44,7 +44,9 @@ class ContactTemplate extends BaseContactTemplate
     {
         $hints = parent::attributeHints();
         $hints['to_email'] = Yii::t('contact', 'One or more email addresses separated by comma');
-        $hints['reply_to_email'] = Yii::t('contact', 'If set, this will be used as Reply-To for all Emails');
+        $hints['reply_to_email'] = Yii::t('contact', 'If set, this will be used as "Reply-To" for ALL Emails');
+        $hints['return_path'] = Yii::t('contact', 'If set, this will be used as "Return-Path" (address for bounce mails)');
+        $hints['reply_to_schema_property'] = Yii::t('contact', 'Email property name from json schema that should be used as "Reply-To" (if reply_to_email is empty)');
         return $hints;
     }
 

--- a/src/models/base/ContactTemplate.php
+++ b/src/models/base/ContactTemplate.php
@@ -14,6 +14,8 @@ use Yii;
  * @property string $from_email
  * @property string $reply_to_email
  * @property string $to_email
+ * @property string $return_path
+ * @property string $reply_to_schema_property
  * @property string $email_subject
  * @property integer $captcha
  * @property string $form_schema
@@ -44,7 +46,7 @@ abstract class ContactTemplate extends \yii\db\ActiveRecord
             [['captcha'], 'integer'],
             [['form_schema'], 'string'],
             [['created_at', 'updated_at'], 'safe'],
-            [['name', 'from_email', 'reply_to_email', 'to_email', 'email_subject'], 'string', 'max' => 255],
+            [['name', 'from_email', 'reply_to_email', 'to_email', 'return_path', 'email_subject', 'reply_to_schema_property'], 'string', 'max' => 255],
             [['name'], 'unique']
         ];
     }
@@ -60,6 +62,8 @@ abstract class ContactTemplate extends \yii\db\ActiveRecord
             'from_email' => Yii::t('models', 'From Email'),
             'reply_to_email' => Yii::t('models', 'Reply To Email'),
             'to_email' => Yii::t('models', 'To Email'),
+            'return_path' => Yii::t('models', 'Return Path'),
+            'reply_to_schema_property' => Yii::t('models', 'Reply to Schema Property'),
             'email_subject' => Yii::t('models', 'Email Subject'),
             'captcha' => Yii::t('models', 'Captcha'),
             'form_schema' => Yii::t('models', 'Form Schema'),

--- a/src/models/base/ContactTemplate.php
+++ b/src/models/base/ContactTemplate.php
@@ -63,7 +63,7 @@ abstract class ContactTemplate extends \yii\db\ActiveRecord
             'reply_to_email' => Yii::t('models', 'Reply To Email'),
             'to_email' => Yii::t('models', 'To Email'),
             'return_path' => Yii::t('models', 'Return Path'),
-            'reply_to_schema_property' => Yii::t('models', 'Reply to Schema Property'),
+            'reply_to_schema_property' => Yii::t('models', 'Reply To Schema Property'),
             'email_subject' => Yii::t('models', 'Email Subject'),
             'captcha' => Yii::t('models', 'Captcha'),
             'form_schema' => Yii::t('models', 'Form Schema'),

--- a/src/models/search/ContactTemplate.php
+++ b/src/models/search/ContactTemplate.php
@@ -27,7 +27,7 @@ class ContactTemplate extends ContactTemplateModel
 	public function rules() {
 		return [
 			[['id'], 'integer'],
-			[['name', 'from_email', 'reply_to_email', 'to_email', 'email_subject', 'form_schema', 'created_at', 'updated_at'], 'safe'],
+			[['name', 'from_email', 'reply_to_email', 'to_email', 'email_subject', 'form_schema', 'return_path', 'reply_to_schema_property','created_at', 'updated_at'], 'safe'],
 		];
 	}
 
@@ -75,7 +75,9 @@ class ContactTemplate extends ContactTemplateModel
 		->andFilterWhere(['like', 'from_email', $this->from_email])
 		->andFilterWhere(['like', 'reply_to_email', $this->reply_to_email])
 		->andFilterWhere(['like', 'to_email', $this->to_email])
-		->andFilterWhere(['like', 'email_subject', $this->email_subject])
+        ->andFilterWhere(['like', 'email_subject', $this->email_subject])
+        ->andFilterWhere(['like', 'return_path', $this->return_path])
+        ->andFilterWhere(['like', 'reply_to_schema_property', $this->reply_to_schema_property])
 		->andFilterWhere(['like', 'form_schema', $this->form_schema]);
 
 		return $dataProvider;

--- a/src/views/crud/contact-template/_form.php
+++ b/src/views/crud/contact-template/_form.php
@@ -63,7 +63,7 @@ use yii\helpers\StringHelper;
 
             <!-- attribute return_path -->
             <?php echo $form->field($model, 'return_path')->textInput(['maxlength' => true]) ?>
-            
+
             <!-- attribute email_subject -->
             <?php echo $form->field($model, 'email_subject')->textInput(['maxlength' => true]) ?>
 

--- a/src/views/crud/contact-template/_form.php
+++ b/src/views/crud/contact-template/_form.php
@@ -55,7 +55,19 @@ use yii\helpers\StringHelper;
 <!-- attribute to_email -->
 			<?php echo $form->field($model, 'to_email')->textInput(['maxlength' => true]) ?>
 
-<!-- attribute captcha -->
+            <!-- attribute reply_to_email -->
+            <?php echo $form->field($model, 'reply_to_email')->textInput(['maxlength' => true]) ?>
+
+            <!-- attribute reply_to_schema_property -->
+            <?php echo $form->field($model, 'reply_to_schema_property')->textInput(['maxlength' => true]) ?>
+
+            <!-- attribute return_path -->
+            <?php echo $form->field($model, 'return_path')->textInput(['maxlength' => true]) ?>
+            
+            <!-- attribute email_subject -->
+            <?php echo $form->field($model, 'email_subject')->textInput(['maxlength' => true]) ?>
+
+            <!-- attribute captcha -->
 			<?php echo                         $form->field($model, 'captcha')->dropDownList(
 	dmstr\modules\contact\models\ContactTemplate::optscaptcha()
 ); ?>
@@ -63,17 +75,6 @@ use yii\helpers\StringHelper;
 <!-- attribute form_schema -->
 			<?php echo $form->field($model, 'form_schema')->textarea(['rows' => 6]) ?>
 
-<!-- attribute created_at -->
-			<?php echo $form->field($model, 'created_at')->textInput() ?>
-
-<!-- attribute updated_at -->
-			<?php echo $form->field($model, 'updated_at')->textInput() ?>
-
-<!-- attribute reply_to_email -->
-			<?php echo $form->field($model, 'reply_to_email')->textInput(['maxlength' => true]) ?>
-
-<!-- attribute email_subject -->
-			<?php echo $form->field($model, 'email_subject')->textInput(['maxlength' => true]) ?>
         </p>
         <?php $this->endBlock(); ?>
 

--- a/src/views/crud/contact-template/index.php
+++ b/src/views/crud/contact-template/index.php
@@ -115,12 +115,14 @@ $actionColumnTemplateString = '<div class="action-buttons">'.$actionColumnTempla
 			'name',
 			'from_email:email',
 			'to_email:email',
+            'reply_to_email:email',
+            'reply_to_schema_property:ntext',
+            'return_path:email',
+            'email_subject:ntext',
 			'captcha',
-			'form_schema:ntext',
-			'created_at',
-			'updated_at',
-			/*'reply_to_email:email',*/
-			/*'email_subject:email',*/
+			/* 'form_schema:ntext', */
+			/* 'created_at', */
+			/* 'updated_at', */
 		],
 	]); ?>
     </div>

--- a/src/views/crud/contact-template/index.php
+++ b/src/views/crud/contact-template/index.php
@@ -6,6 +6,7 @@
  */
 
 
+use dmstr\modules\contact\models\ContactTemplate;
 use yii\helpers\Html;
 use yii\helpers\Url;
 use yii\grid\GridView;
@@ -63,7 +64,10 @@ $actionColumnTemplateString = '<div class="action-buttons">'.$actionColumnTempla
 			],
 			'encodeLabels' => false,
 			'items' => [
-
+                [
+                    'url' => ['/prototype/twig/index', 'Twig[key]' => ContactTemplate::TMPL_PREFIX],
+                    'label' => '<i class="glyphicon glyphicon-arrow-left"></i> ' . Yii::t('cruds', 'Twig Templates'),
+                ],
 			]
 		],
 		'options' => [

--- a/src/views/crud/contact-template/view.php
+++ b/src/views/crud/contact-template/view.php
@@ -107,13 +107,13 @@ $this->params['breadcrumbs'][] = Yii::t('cruds', 'View');
     <?php echo DetailView::widget([
 		'model' => $model,
 		'attributes' => [
-			'name',
+			'name:ntext',
 			'from_email:email',
 			'to_email:email',
             'reply_to_email:email',
-            'reply_to_schema_property',
-            'return_path',
-            'email_subject:email',
+            'reply_to_schema_property:ntext',
+            'return_path:email',
+            'email_subject:ntext',
 			'captcha',
             [
                 'attribute' => 'form_schema',

--- a/src/views/crud/contact-template/view.php
+++ b/src/views/crud/contact-template/view.php
@@ -6,6 +6,7 @@
  */
 
 
+use dmstr\modules\contact\models\ContactTemplate;
 use yii\helpers\Html;
 use yii\helpers\Url;
 use yii\grid\GridView;
@@ -62,9 +63,36 @@ $this->params['breadcrumbs'][] = Yii::t('cruds', 'View');
 	'<span class="glyphicon glyphicon-plus"></span> ' . Yii::t('cruds', 'New'),
 	['create'],
 	['class' => 'btn btn-success']) ?>
+
+            <?php
+            $tmplName = ContactTemplate::TMPL_PREFIX . $model->name;
+            if ($twig = \dmstr\modules\prototype\models\Twig::findOne(['key' => $tmplName])) {
+                echo Html::a('<span class="glyphicon glyphicon-file"></span> '
+                             . Yii::t('cruds', 'Form Twig'), ['/prototype/twig/view', 'id' => $twig->id], ['class'=>'btn btn-success']);
+            } else {
+                echo Html::a('<span class="glyphicon glyphicon-file"></span> '
+                             . Yii::t('cruds', 'Create Form Twig'), ['/prototype/twig/create', 'Twig[key]' => $tmplName], ['class'=>'btn btn-warning']);
+
+            }
+            ?>
+
+            <?php
+            $tmplName = ContactTemplate::TMPL_PREFIX . $model->name . ContactTemplate::TMPL_SEND_SUFFIX;
+            if ($twig = \dmstr\modules\prototype\models\Twig::findOne(['key' => $tmplName])) {
+                echo Html::a('<span class="glyphicon glyphicon-file"></span> '
+                             . Yii::t('cruds', 'Send Twig'), ['/prototype/twig/view', 'id' => $twig->id], ['class'=>'btn btn-success']);
+            } else {
+                echo Html::a('<span class="glyphicon glyphicon-file"></span> '
+                             . Yii::t('cruds', 'Create Send Twig'), ['/prototype/twig/create', 'Twig[key]' => $tmplName], ['class'=>'btn btn-warning']);
+
+            }
+            ?>
         </div>
 
         <div class="pull-right">
+            <?php echo Html::a('<span class="glyphicon glyphicon-eye-open"></span> '
+                               . Yii::t('cruds', 'View in Frontend'), ['/contact/default', 'schema' => $model->name], ['class'=>'btn btn-default']) ?>
+
             <?php echo Html::a('<span class="glyphicon glyphicon-list"></span> '
 	. Yii::t('cruds', 'Full list'), ['index'], ['class'=>'btn btn-default']) ?>
         </div>

--- a/src/views/crud/contact-template/view.php
+++ b/src/views/crud/contact-template/view.php
@@ -82,12 +82,18 @@ $this->params['breadcrumbs'][] = Yii::t('cruds', 'View');
 			'name',
 			'from_email:email',
 			'to_email:email',
+            'reply_to_email:email',
+            'reply_to_schema_property',
+            'return_path',
+            'email_subject:email',
 			'captcha',
-			'form_schema:ntext',
-			'created_at',
-			'updated_at',
-			'reply_to_email:email',
-			'email_subject:email',
+            [
+                'attribute' => 'form_schema',
+                'format' => 'raw',
+                'value' => "<pre>" . htmlspecialchars($model->form_schema) . "</pre>",
+            ],
+            'created_at',
+            'updated_at',
 		],
 	]); ?>
 

--- a/src/views/default/done-expired.php
+++ b/src/views/default/done-expired.php
@@ -1,0 +1,19 @@
+<?php
+
+use dmstr\modules\contact\models\ContactLog;
+use dmstr\modules\contact\models\ContactTemplate;
+use dmstr\modules\prototype\widgets\TwigWidget;
+
+/**
+ * @var $schema string
+ * @var $model ContactLog
+ */
+?>
+
+<div class="container text-center">
+    <div class="row">
+    <div class=" col-xs-12 alert alert-success">
+        <?= Yii::t('contact', "The message has already been sent.") ?>
+    </div>
+    </div>
+</div>

--- a/src/views/default/done-expired.php
+++ b/src/views/default/done-expired.php
@@ -12,8 +12,10 @@ use dmstr\modules\prototype\widgets\TwigWidget;
 
 <div class="container text-center">
     <div class="row">
-    <div class=" col-xs-12 alert alert-success">
-        <?= Yii::t('contact', "The message has already been sent.") ?>
-    </div>
+        <div class=" col-xs-12">
+            <div class="alert alert-success">
+                <?= Yii::t('contact', "The message has already been sent.") ?>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/views/default/done.php
+++ b/src/views/default/done.php
@@ -1,6 +1,7 @@
 <?php
 
 use dmstr\modules\contact\models\ContactLog;
+use dmstr\modules\contact\models\ContactTemplate;
 use dmstr\modules\prototype\widgets\TwigWidget;
 
 /**
@@ -12,7 +13,7 @@ use dmstr\modules\prototype\widgets\TwigWidget;
 <?=
  TwigWidget::widget(
     [
-        'key' => 'contact:' . $schema . ':send',
+        'key' => ContactTemplate::TMPL_PREFIX . $schema . ContactTemplate::TMPL_SEND_SUFFIX,
         'params' => [
             'model' => $model,
         ]

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use dmstr\modules\contact\models\ContactLog;
+use dmstr\modules\contact\models\ContactTemplate;
 use dmstr\modules\prototype\widgets\TwigWidget;
 
 /**
@@ -12,7 +13,7 @@ use dmstr\modules\prototype\widgets\TwigWidget;
 
 <?= TwigWidget::widget(
     [
-        'key' => 'contact:' . $schema,
+        'key' => ContactTemplate::TMPL_PREFIX . $schema,
         'params' => [
             'model' => $model,
             'schema' => $schemaData,


### PR DESCRIPTION
Background: 
- In bd20d1014516117255733cad41c24ca78c1a0b48 and ff. the feature to set reply-to header from form value (via schema property name 'reply_to') was "removed.
- a "new" property `reply_to_email` was added to the template, which - if set - is used as a "fixed" reply-to for all sended mails. This can be useful, but is not a generic solution to set the reply-to header.
- the optional property to set the return-path header (for bounce mails) was also removed
- During the refactoring, unfortunately, also the validation of the mail addresses when editing the templates and before sending the mails are lost.

This PR:
- restores the optional feature to get reply-to from schema property.  The fixed `reply_to_email` address - if set - has priority.
- restores the optional feature to set a return-path address
- re-add email-validations while editing templates and before sending the mails
- and while we are at it, the backend GUI has been improved as well (relation links, better formatting,...)

As we need these "features" also in "older" projects, this PR should be merged in the `release/2.0.x` branch first, and must then be ported to the `3.*` and `master` branches.